### PR TITLE
Add Cricket Club with Blue Indian team theme

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "Cricket Club": {
+        "description": "Join our cricket team and represent the Man with Blue Indian team colors. Learn cricket fundamentals, practice batting and bowling techniques, and compete in inter-school matches",
+        "schedule": "Monday to Friday, 4:40 PM - 5:00 PM",
+        "max_participants": 10,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
# Add Cricket Club with Blue Indian team theme

## Summary
Added a new Cricket Club activity to the Mergington High School extracurricular activities system. The Cricket Club includes a description referencing "the Man with Blue Indian team colors", runs Monday through Friday from 4:40-5:00 PM, and has availability for 10 participants.

## Review & Testing Checklist for Human
- [ ] **Verify description interpretation**: Confirm that referencing "Man with Blue Indian team colors" in the context of cricket team identity makes sense for your intended use case
- [ ] **Test functionality locally**: Run the app (`uvicorn src.app:app --reload --host 0.0.0.0 --port 8000`) and verify Cricket Club displays correctly with proper schedule, availability, and signup/unregister functionality
- [ ] **Check UI display**: Confirm the Cricket Club card looks consistent with other activities and the Monday-Friday schedule displays appropriately

### Notes
- This change follows the existing activity data structure pattern exactly
- No frontend changes were needed as the UI automatically displays all activities from the API
- Implemented and tested locally - Cricket Club appears in both the activities list and signup dropdown

**Link to Devin run:** https://app.devin.ai/sessions/5a432bee53cc45f2a227352adaa797be  
**Requested by:** @rajmanjit-design